### PR TITLE
Update routine name in Wildfire Cosimulation Game

### DIFF
--- a/examples/wildfire_cosimulation_game.ipynb
+++ b/examples/wildfire_cosimulation_game.ipynb
@@ -612,7 +612,7 @@
    "outputs": [],
    "source": [
     "routines = agent_template.Routine.get_all()  # get all routine blocks\n",
-    "root_routine = [routine for routine in routines if routine.name == \"Root Routine\"][0]  # get root routine block\n",
+    "root_routine = [routine for routine in routines if routine.name == \"Default Main Routine\"][0]  # get root routine block\n",
     "subroutine_blocks = [routine for routine in routines if routine in root_routine.subroutines]  # get subroutine blocks"
    ]
   },


### PR DESCRIPTION
This changes the expected name of Wildfire's root routine from `Root Routine` to `Default Main Routine`.