### PR TITLE
Set SuperDove sim start to current MJD day

### DIFF
--- a/examples/build_superdove_constellation.ipynb
+++ b/examples/build_superdove_constellation.ipynb
@@ -164,6 +164,28 @@
     "scenario_branch.crud(blocks=orbits + agents)\n",
     "print(f'Created {len(tles)} orbits from TLEs and {len(tles)} spacecraft digital twin agents.')"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Update Simulation Clock\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime, UTC\n",
+    "\n",
+    "mjd_days = (datetime.now(UTC) - datetime(year=1858, month=11, day=17, tzinfo=UTC)).days\n",
+    "scenario_branch.ClockConfig.get_first().update(\n",
+    "    startTime=mjd_days,\n",
+    "    stopTime=mjd_days + 1\n",
+    ")"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
This adds a cell to the `build_superdove_constellation.ipynb` notebook that updates the simulation's `ClockConfig` to start at the beginning of today's MJD date.