### PR TITLE
Update notebooks for new 4.13 syntax

### DIFF
--- a/examples/build_superdove_constellation.ipynb
+++ b/examples/build_superdove_constellation.ipynb
@@ -103,7 +103,7 @@
     "if not delete_ids:\n",
     "    print('No blocks were deleted')\n",
     "else:\n",
-    "    scenario_branch.crud(delete=delete_ids)\n",
+    "    scenario_branch.update(delete=delete_ids)\n",
     "    print(f'Deleted {len(delete_ids)} spacecraft digital twin agents.')"
    ]
   },
@@ -161,7 +161,7 @@
     "    } for tle in tles\n",
     "]\n",
     "\n",
-    "scenario_branch.crud(blocks=orbits + agents)\n",
+    "scenario_branch.update(blocks=orbits + agents)\n",
     "print(f'Created {len(tles)} orbits from TLEs and {len(tles)} spacecraft digital twin agents.')"
    ]
   },

--- a/examples/flower_constellation.ipynb
+++ b/examples/flower_constellation.ipynb
@@ -226,7 +226,7 @@
     "    agent_ids = [entry.id for entry in scenario_branch.Agent.get_all()]\n",
     "    orbit_ids = [entry.id for entry in scenario_branch.Orbit.get_all()]\n",
     "    if len(agent_ids) + len(orbit_ids) > 0:\n",
-    "        scenario_branch.crud(delete=(agent_ids + orbit_ids))\n",
+    "        scenario_branch.update(delete=(agent_ids + orbit_ids))\n",
     "    agent_id_offset = 0\n",
     "else:\n",
     "    agent_id_offset = len(scenario_branch.Agent.get_all())\n",
@@ -259,7 +259,7 @@
     "\n",
     "    orbits_and_agents.extend([orbit, agent])\n",
     "\n",
-    "result = scenario_branch.crud(blocks=orbits_and_agents)\n",
+    "result = scenario_branch.update(blocks=orbits_and_agents, include_response=True)\n",
     "orbit_and_agent_ids = result['crud']['blocks']"
    ]
   },
@@ -300,7 +300,7 @@
    "outputs": [],
    "source": [
     "# Delete created Agents and Orbits\n",
-    "scenario_branch.crud(delete=orbit_and_agent_ids)"
+    "scenario_branch.update(delete=orbit_and_agent_ids)"
    ]
   }
  ],

--- a/examples/wildfire_cosimulation_game.ipynb
+++ b/examples/wildfire_cosimulation_game.ipynb
@@ -84,83 +84,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Simple Conversion Functions\n",
-    "\n",
-    "Sedaro outputs the simulation time in MJD and angles in radians. These functions will help to convert MJD dates to `datetime` objects and radians to degrees for easier interpretation.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from math import pi\n",
-    "from datetime import datetime, timedelta\n",
-    "\n",
-    "\n",
-    "def mjd2dt(mjd: float) -> datetime:\n",
-    "    \"\"\"Convert Modified Julian Date (MJD) float to datetime object.\"\"\"\n",
-    "    return datetime(1858, 11, 17) + timedelta(days=mjd)\n",
-    "\n",
-    "\n",
-    "def rad2deg(rad: float) -> float:\n",
-    "    \"\"\"Convert radians to degrees.\"\"\"\n",
-    "    return rad * 180 / pi"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Rotation & Quaternion Functions\n",
-    "\n",
-    "Below are functions that will allow us to calculate the rotation matrix of a quaternion and convert between the spacecraft body frame and the Local-Vertical/Local-Horizontal (LVLH) frame. Expressing vectors with LVLH components will allow us to calculate yaw and pitch in an intuitive frame of reference.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import numpy as np\n",
-    "\n",
-    "\n",
-    "def quaternion2RotMat(quaternion: np.ndarray) -> np.ndarray:\n",
-    "    \"\"\"Convert quaternion to rotation matrix.\"\"\"\n",
-    "    if len(quaternion) != 4:\n",
-    "        raise ValueError(\"Bad shape\")\n",
-    "\n",
-    "    rotation = np.zeros((3, 3))\n",
-    "\n",
-    "    rotation[0, 0] = 1 - 2 * (quaternion[1] * quaternion[1] + quaternion[2] * quaternion[2])\n",
-    "    rotation[1, 0] = 2 * (quaternion[0] * quaternion[1] + quaternion[3] * quaternion[2])\n",
-    "    rotation[2, 0] = 2 * (quaternion[0] * quaternion[2] - quaternion[3] * quaternion[1])\n",
-    "\n",
-    "    rotation[0, 1] = 2 * (quaternion[0] * quaternion[1] - quaternion[3] * quaternion[2])\n",
-    "    rotation[1, 1] = 1 - 2 * (quaternion[0] * quaternion[0] + quaternion[2] * quaternion[2])\n",
-    "    rotation[2, 1] = 2 * (quaternion[1] * quaternion[2] + quaternion[3] * quaternion[0])\n",
-    "\n",
-    "    rotation[0, 2] = 2 * (quaternion[0] * quaternion[2] + quaternion[3] * quaternion[1])\n",
-    "    rotation[1, 2] = 2 * (quaternion[1] * quaternion[2] - quaternion[3] * quaternion[0])\n",
-    "    rotation[2, 2] = 1 - 2 * (quaternion[0] * quaternion[0] + quaternion[1] * quaternion[1])\n",
-    "\n",
-    "    return rotation\n",
-    "\n",
-    "\n",
-    "def body2Lvlh(attitude, lvlh_to_eci):\n",
-    "    \"\"\"Calculate body to LVLH rotation matrix.\"\"\"\n",
-    "    body_to_eci = quaternion2RotMat(attitude)  # body to ECI rotation matrix\n",
-    "    eci_to_lvlh = lvlh_to_eci.T  # transpose for ECI to LVLH rotation matrix\n",
-    "    body_to_lvlh = eci_to_lvlh @ body_to_eci  # body to LVLH rotation matrix\n",
-    "    return body_to_lvlh"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Keyboard Input\n",
     "\n",
     "This notebook utilizes the `pynput` package to interpret keypresses and trigger actions depending on which keys are pressed. These functions define the behavior of the `on_press` and `on_release` callbacks for the keyboard listener. The default keybindings for the `on_press` keypress callback are as follows:\n",
@@ -254,7 +177,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from datetime import datetime\n",
     "from time import sleep\n",
+    "\n",
+    "import numpy as np\n",
+    "from sedaro import modsim as ms\n",
     "\n",
     "\n",
     "class Game:\n",
@@ -302,8 +229,11 @@
     "\n",
     "    def calcYawPitch(self, thruster):\n",
     "        \"\"\"Calculate the yaw and pitch angles of the thrust vector in the ram frame\"\"\"\n",
+    "        body_to_eci = ms.quaternion2rotmat(self.attitude)  # body to ECI rotation matrix\n",
+    "        eci_to_lvlh = self.lvlh2Eci.T  # transpose for ECI to LVLH rotation matrix\n",
+    "        body_to_lvlh = eci_to_lvlh @ body_to_eci  # body to LVLH rotation matrix\n",
     "        vector = -thruster.exhaustVector  # thrust vector in body frame\n",
-    "        vector = body2Lvlh(self.attitude, self.lvlh2Eci) @ vector  # vector in LVLH frame\n",
+    "        vector = body_to_lvlh @ vector  # vector in LVLH frame\n",
     "        self.yaw = -np.arctan2(vector[2], vector[1])  # yaw angle from ram in LVLH frame\n",
     "        self.pitch = np.arcsin(vector[0])  # pitch angle from ram in LVLH frame\n",
     "\n",
@@ -360,7 +290,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from math import degrees\n",
+    "\n",
     "from IPython.display import clear_output\n",
+    "from sedaro import modsim as ms\n",
     "\n",
     "\n",
     "def bar(num: float, minimum: float, maximum: float, start: float = 0, width: int = 101):\n",
@@ -390,7 +323,7 @@
     "    info_string = \"\\n\".join([\n",
     "        f\"{bold}Loop Time{reset}:           {game.loopTime:.4f} seconds\",\n",
     "        \"\",\n",
-    "        f\"{bold}Simulation Time{reset}:     {update_color if update else ''}{mjd2dt(game.time)}{reset}\",\n",
+    "        f\"{bold}Simulation Time{reset}:     {update_color if update else ''}{ms.mjd_to_datetime(game.time)}{reset}\",\n",
     "        \"\",\n",
     "        f\"{bold}Routine{reset}:             [{sat.routines.index(sat.activeRoutine) + 1}] {sat.activeRoutine.name}\",\n",
     "        \"\",\n",
@@ -399,8 +332,8 @@
     "        f\"  Perigee:           {sat.perigee:9.4f} km\",\n",
     "        \"\",\n",
     "        f\"{bold}---- Attitude ----{reset}\",\n",
-    "        f\"  Yaw from Ram:      {bar(rad2deg(sat.yaw), -180, 180)} {rad2deg(sat.yaw):7.2f}\\u00B0\",\n",
-    "        f\"  Pitch from Ram:    {bar(rad2deg(sat.pitch), -90, 90)} {rad2deg(sat.pitch):7.2f}\\u00B0\",\n",
+    "        f\"  Yaw from Ram:      {bar(degrees(sat.yaw), -180, 180)} {degrees(sat.yaw):7.2f}\\u00B0\",\n",
+    "        f\"  Pitch from Ram:    {bar(degrees(sat.pitch), -90, 90)} {degrees(sat.pitch):7.2f}\\u00B0\",\n",
     "        \"\",\n",
     "        f\"{bold}---- Actuators ----{reset}\",\n",
     "        f\"                          {bold}Actuation{reset}      |                                                {bold}Capacity{reset}\",\n",
@@ -461,8 +394,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if len(extStateIDs := scenario.ExternalState.get_all_ids()) > 0:  # if there are any existing ExternalState blocks\n",
-    "    scenario.crud(delete=extStateIDs)  # delete all ExternalState blocks"
+    "scenario.delete_all_external_state_blocks()"
    ]
   },
   {
@@ -648,40 +580,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Starting Simulation & Listener\n",
-    "\n",
-    "These blocks will start the simulation and the keyboard listener. Starting the simulation can take longer for more complicated scenarios, so you may need to give it some time (~30 seconds). After the simulation is started, the code block below will print a link that you can use to view the scenario results in a web browser.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# start the simulation and wait for it to initialize (this will take a few seconds)\n",
-    "simulation_handle = simulation.start(wait=True)\n",
-    "# print link to scenario results\n",
-    "print(\n",
-    "    f\"View the scenario results at {WEB_HOST}/#/agent-analyze/{SCENARIO_BRANCH_ID}/custom/playback?agentId={WILDFIRE_ID}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "listener.start()  # start non-blocking keyboard listener in another thread"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Game Loop\n",
     "\n",
-    "This block contains the game loop, which will continue to run while the keyboard listener is active and the simulation is running. The game loop performs the following steps during each iteration:\n",
+    "This block will start the simulation and the keyboard listener and then enter the game loop. Starting the simulation can take longer for more complicated scenarios, so you may need to give it some time (~30 seconds). The game loop will continue to run while the keyboard listener is active and the simulation is running. The game loop performs the following steps during each iteration:\n",
     "\n",
     "1.  Start the game loop timer\n",
     "2.  Set the simulation update variable (`sim_updated`) to `False`\n",
@@ -702,69 +603,91 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "while listener.running and simulation_handle.status()['status'] == 'RUNNING':\n",
-    "    game.startLoop()  # start Game loop timer\n",
-    "    sim_updated = False  # set simulation updated flag to False at the start of each loop\n",
+    "# start the simulation and wait for it to initialize (this will take a few seconds)\n",
+    "with simulation.start(wait=True) as simulation_handle:\n",
+    "    listener.start()  # start non-blocking keyboard listener in another thread\n",
+    "    while listener.running:\n",
+    "        game.startLoop()  # start Game loop timer\n",
+    "        sim_updated = False  # set simulation updated flag to False at the start of each loop\n",
     "\n",
-    "    # Consume & produce simulation state\n",
-    "    # query the simulation for the current GNC state\n",
-    "    gnc_state = simulation_handle.consume(agent_id=WILDFIRE_ID, external_state_id=GNC_STATE_ID)\n",
-    "    simulation_handle.produce(agent_id=WILDFIRE_ID,\n",
-    "                              external_state_id=GNC_STATE_ID,\n",
-    "                              values=(\n",
-    "                                  [RWs['X'].torque, RWs['Y'].torque, RWs['Z'].torque],\n",
-    "                                  [thruster.thrust]))\n",
-    "    simulation_handle.produce(agent_id=WILDFIRE_ID,\n",
-    "                              external_state_id=CDH_STATE_ID,\n",
-    "                              values=([sat.activeRoutine.id,],))\n",
-    "    # query the simulation for the current Power state\n",
-    "    power_state = simulation_handle.consume(agent_id=WILDFIRE_ID, external_state_id=POWER_STATE_ID)\n",
+    "        # Consume & produce simulation state\n",
+    "        # query the simulation for the current GNC state\n",
+    "        gnc_state = simulation_handle.consume(agent_id=WILDFIRE_ID, external_state_id=GNC_STATE_ID)\n",
+    "        simulation_handle.produce(agent_id=WILDFIRE_ID,\n",
+    "                                external_state_id=GNC_STATE_ID,\n",
+    "                                values=(\n",
+    "                                    [RWs['X'].torque, RWs['Y'].torque, RWs['Z'].torque],\n",
+    "                                    [thruster.thrust]))\n",
+    "        simulation_handle.produce(agent_id=WILDFIRE_ID,\n",
+    "                                external_state_id=CDH_STATE_ID,\n",
+    "                                values=([sat.activeRoutine.id,],))\n",
+    "        # query the simulation for the current Power state\n",
+    "        power_state = simulation_handle.consume(agent_id=WILDFIRE_ID, external_state_id=POWER_STATE_ID)\n",
     "\n",
-    "    # Parse simulation output\n",
-    "    (\n",
-    "        time,  # simulation time [MJD]\n",
-    "        attitude,  # attitude quaternion\n",
-    "        lvlhAxes,  # LVLH to ECI rotation matrix\n",
-    "        momentum,  # reaction wheel momentum list\n",
-    "        wetMass,  # tank fuel list [kg]\n",
-    "        apogee,  # apogee list [km]\n",
-    "        perigee  # perigee list [km]\n",
-    "    ) = gnc_state  # unpack the GNC state tuple\n",
-    "    (\n",
-    "        stateOfCharge,  # battery state of charge list\n",
-    "        powerLoading,  # power processor output power list\n",
-    "        solarUtilization,  # solar array utilization list\n",
-    "    ) = power_state  # unpack the power state tuple\n",
+    "        # Parse simulation output\n",
+    "        (\n",
+    "            time,  # simulation time [MJD]\n",
+    "            attitude,  # attitude quaternion\n",
+    "            lvlhAxes,  # LVLH to ECI rotation matrix\n",
+    "            momentum,  # reaction wheel momentum list\n",
+    "            wetMass,  # tank fuel list [kg]\n",
+    "            apogee,  # apogee list [km]\n",
+    "            perigee  # perigee list [km]\n",
+    "        ) = gnc_state  # unpack the GNC state tuple\n",
+    "        (\n",
+    "            stateOfCharge,  # battery state of charge list\n",
+    "            powerLoading,  # power processor output power list\n",
+    "            solarUtilization,  # solar array utilization list\n",
+    "        ) = power_state  # unpack the power state tuple\n",
     "\n",
-    "    # Update fields\n",
-    "    game.time = time  # update game time\n",
-    "    sat.attitude = attitude  # update attitude quaternion\n",
-    "    sat.lvlh2Eci = lvlhAxes  # update LVLH axes\n",
-    "    sat.calcYawPitch(thruster)  # calculate yaw and pitch angles\n",
-    "    for rw, m in zip(RWs.values(), momentum):\n",
-    "        rw.momentum = m  # update reaction wheel momentum\n",
-    "    thruster.fuel = sum(wetMass)  # update thruster fuel\n",
-    "    sat.apogee = apogee[0]  # update apogee\n",
-    "    sat.perigee = perigee[0]  # update perigee\n",
-    "    sat.stateOfCharge = stateOfCharge[0]\n",
-    "    sat.powerLoading = powerLoading[0]['total']  # update total power loading\n",
-    "    totalUtilization = sum([(util if not np.isnan(util) else 0)\n",
-    "                           for util in solarUtilization])  # sum utilization values, ignoring NaNs\n",
-    "    sat.solarUtilization = totalUtilization / len(solarUtilization)  # update average solar array utilization\n",
+    "        # Update fields\n",
+    "        game.time = time  # update game time\n",
+    "        sat.attitude = attitude  # update attitude quaternion\n",
+    "        sat.lvlh2Eci = lvlhAxes  # update LVLH axes\n",
+    "        sat.calcYawPitch(thruster)  # calculate yaw and pitch angles\n",
+    "        for rw, m in zip(RWs.values(), momentum):\n",
+    "            rw.momentum = m  # update reaction wheel momentum\n",
+    "        thruster.fuel = sum(wetMass)  # update thruster fuel\n",
+    "        sat.apogee = apogee[0]  # update apogee\n",
+    "        sat.perigee = perigee[0]  # update perigee\n",
+    "        sat.stateOfCharge = stateOfCharge[0]\n",
+    "        sat.powerLoading = powerLoading[0]['total']  # update total power loading\n",
+    "        totalUtilization = sum([(util if not np.isnan(util) else 0)\n",
+    "                            for util in solarUtilization])  # sum utilization values, ignoring NaNs\n",
+    "        sat.solarUtilization = totalUtilization / len(solarUtilization)  # update average solar array utilization\n",
     "\n",
-    "    sim_updated = game.update()  # detect if the simulation time has changed & update Game clock\n",
-    "    game.endLoop()  # end Game loop timer\n",
-    "    display(sim_updated, game, sat, RWs, thruster)  # update display output\n",
-    "    game.wait()  # wait if necessary"
+    "        sim_updated = game.update()  # detect if the simulation time has changed & update Game clock\n",
+    "        game.endLoop()  # end Game loop timer\n",
+    "        display(sim_updated, game, sat, RWs, thruster)  # update display output\n",
+    "        game.wait()  # wait if necessary"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Stopping Simulation & Listener\n",
+    "### Results\n",
     "\n",
-    "If they have not already stopped running after ending the game loop, the two blocks below will stop the keyboard listener and terminate the simulation.\n"
+    "The will print a link that you can use to view the scenario results in a web browser."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\n",
+    "    f\"View the scenario results at {WEB_HOST}/#/agent-analyze/{SCENARIO_BRANCH_ID}/custom/playback?agentId={WILDFIRE_ID}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Stopping Listener\n",
+    "\n",
+    "If it has not already stopped running after ending the game loop, this will stop the keyboard listener.\n"
    ]
   },
   {
@@ -774,18 +697,6 @@
    "outputs": [],
    "source": [
     "listener.stop()  # stop keyboard listener if it hasn't been stopped already"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "try:\n",
-    "    simulation_handle.terminate()  # stop simulation if it hasn't stopped already\n",
-    "except:\n",
-    "    pass"
    ]
   }
  ],

--- a/model_validation/attitude_dynamics/build_scenario.ipynb
+++ b/model_validation/attitude_dynamics/build_scenario.ipynb
@@ -69,14 +69,14 @@
                 "        return -float(s[0])\n",
                 "\n",
                 "# Add stations as agent and as tg\n",
-                "crud = []\n",
+                "blocks = []\n",
                 "names = []\n",
                 "for _, row in stations.iterrows():\n",
                 "    name = row['Train Station']\n",
                 "    if name in names:\n",
                 "        name = row['City'] + ' ' + name\n",
                 "    names.append(name)\n",
-                "    crud.append({\n",
+                "    blocks.append({\n",
                 "        'name': name[:32],\n",
                 "        'type': 'PeripheralGroundPoint',\n",
                 "        'lat': {'deg': get_lat(row['Latitude'])},\n",
@@ -85,13 +85,13 @@
                 "        'id': f'${name}',\n",
                 "        'kinematics': kinematics.id,\n",
                 "    })\n",
-                "crud.append({\n",
+                "blocks.append({\n",
                 "    'name': 'Some Train Stations',\n",
                 "    'type': 'AgentGroup',\n",
                 "    'agentType': 'GroundTarget',\n",
                 "    'agentAssociations': {f'${name}': {'priority': i} for i, name in enumerate(names)},\n",
                 "})\n",
-                "_ = scenario.crud(blocks=crud)"
+                "_ = scenario.update(blocks=blocks)"
             ]
         },
         {

--- a/model_validation/gravity/build_scenario.py
+++ b/model_validation/gravity/build_scenario.py
@@ -65,5 +65,5 @@ if __name__ == '__main__':
     # Delete existing agents and create new ones
     existing = scenario.Agent.get_all()
     if existing:
-        scenario.crud(delete=[entry.id for entry in existing])
-    scenario.crud(blocks=blocks)
+        scenario.update(delete=[entry.id for entry in existing])
+    scenario.update(blocks=blocks)


### PR DESCRIPTION
This makes updates to the notebooks to support new syntax in the `sedaro` package coming in Sedaro 4.13.

- Replaces `crud` calls with `update`
- Uses the `with sim.start() as simulation_handle` context manager where appropriate
- Uses `scenario.delete_all_external_state_blocks` where applicable
- Uses new `modsim` functions included in the `sedaro` package