### PR TITLE
Add SimStats to results api notebook

### DIFF
--- a/examples/results_api_demo.ipynb
+++ b/examples/results_api_demo.ipynb
@@ -320,7 +320,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "series_with_stats('min', 'max')"
+    "series_with_stats.stats('min', 'max')"
    ]
   },
   {
@@ -329,7 +329,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "series_with_stats('average')"
+    "series_with_stats.stats('average')"
    ]
   },
   {
@@ -479,9 +479,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "block_with_stats.temperature.degC.plot(show=False)\n",
-    "block_with_stats.hotMargin(show=False, xlabel='Hot Margin (C)')\n",
-    "block_with_stats.coldMargin()"
+    "block_with_stats.temperature.degC.plot_stats(show=False)\n",
+    "block_with_stats.hotMargin.plot_stats(show=False, xlabel='Hot Margin (C)')\n",
+    "block_with_stats.coldMargin.plot_stats()"
    ]
   }
  ],

--- a/examples/results_api_demo.ipynb
+++ b/examples/results_api_demo.ipynb
@@ -240,6 +240,103 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Calling `.summarize` at the `Block` level will indicate which, if any, of the `Block`'s member series have statistics calculated."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "block_with_stats = result.agent('Wildfire').block('NYTzPowStDhWKzEndl0PV')\n",
+    "block_with_stats.summarize()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To fetch all the stats for a Block, simply call `.stats`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "block_with_stats.stats()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Alternatively, you can pass one or more specific statistics as arguments to `.stats`, and for each one a dictionary will be returned containing all such stats for the Block:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "block_with_stats.stats('min', 'max')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "block_with_stats.stats('average')"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`.stats` may also be used in the same manner at the `Series` level."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "series_with_stats = block_with_stats.temperature.degC\n",
+    "series_with_stats.stats()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "series_with_stats('min', 'max')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "series_with_stats('average')"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Saving and Loading Results Locally\n",
     "\n",
     "Every Sedaro result object supports saving and restoring results to and from a file. This functionality can be helpful when working with large results to avoid re-downloading the same data. To save data, call the `.save` method on any result object. Note that the save operation saves the object's data as a directory. If the specified path does not exist, a directory in that location will be created. If a non-empty directory, or a file, is specified, the operation will return an error."
@@ -366,6 +463,25 @@
    "outputs": [],
    "source": [
     "block_result.position.ecef.plot(linewidth=1, ylabel='ECEF position (km)')"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Like series data, sim stats can also be plotted. To do so, use `.plot_stats`. This is most useful for comparing summary stats side by side for several series. `xlabel` and `show` parameters are supported."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "block_with_stats.temperature.degC.plot(show=False)\n",
+    "block_with_stats.hotMargin(show=False, xlabel='Hot Margin (C)')\n",
+    "block_with_stats.coldMargin()"
    ]
   }
  ],

--- a/examples/results_api_demo.ipynb
+++ b/examples/results_api_demo.ipynb
@@ -219,6 +219,27 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Sim Stats\n",
+    "\n",
+    "Beginning with Sedaro 4.13, summary statistics are calculated for certain state variables. They become available shortly after a simulation finishes running. Note that these stats are for the entire duration of the sim, even if you fetch data for only a part of the duration.\n",
+    "\n",
+    "If the stats were not yet ready when you initially fetched results, you may fetch them later at any time at the `SimulationResult` level:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result.fetch_stats()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Saving and Loading Results Locally\n",
     "\n",
     "Every Sedaro result object supports saving and restoring results to and from a file. This functionality can be helpful when working with large results to avoid re-downloading the same data. To save data, call the `.save` method on any result object. Note that the save operation saves the object's data as a directory. If the specified path does not exist, a directory in that location will be created. If a non-empty directory, or a file, is specified, the operation will return an error."

--- a/examples/results_api_demo.ipynb
+++ b/examples/results_api_demo.ipynb
@@ -470,7 +470,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Like series data, sim stats can also be plotted. To do so, use `.plot_stats`. This is most useful for comparing summary stats side by side for several series. `xlabel` and `show` parameters are supported."
+    "Like series data, sim stats can also be plotted. To do so, use `.plot_stats`. This is most useful for comparing summary stats for several series side by side. `xlabel` and `show` parameters are supported."
    ]
   },
   {


### PR DESCRIPTION
Add SimStats information and examples to Results API notebook. NOTE: don't merge until 4.13 is live on prod.

Closes https://gitlab.sedaro.com/sedaro-satellite/modsim/-/issues/218