### PR TITLE
account for running event loop in jupyter

### DIFF
--- a/benchmarking/cosim_latency.ipynb
+++ b/benchmarking/cosim_latency.ipynb
@@ -81,7 +81,6 @@
    "outputs": [],
    "source": [
     "import time\n",
-    "import os\n",
     "from sedaro import SedaroApiClient\n",
     "import json\n",
     "import matplotlib.pyplot as plt\n",
@@ -187,10 +186,7 @@
     "            print('A exception was raised.  This is expected if the simulation terminated successfully.  Original exception:', e)\n",
     "            pass\n",
     "\n",
-    "try:\n",
-    "    asyncio.run(cosimulate())\n",
-    "except RuntimeError:\n",
-    "    await cosimulate()"
+    "await cosimulate()"
    ]
   },
   {

--- a/benchmarking/cosim_latency.ipynb
+++ b/benchmarking/cosim_latency.ipynb
@@ -187,7 +187,10 @@
     "            print('A exception was raised.  This is expected if the simulation terminated successfully.  Original exception:', e)\n",
     "            pass\n",
     "\n",
-    "asyncio.run(cosimulate())"
+    "try:\n",
+    "    asyncio.run(cosimulate())\n",
+    "except RuntimeError:\n",
+    "    await cosimulate()"
    ]
   },
   {

--- a/examples/ground_segment_scheduling/optimization_cosimulation.ipynb
+++ b/examples/ground_segment_scheduling/optimization_cosimulation.ipynb
@@ -388,7 +388,10 @@
     "                    await channel.produce(agent_id=gs_agent.id, external_state_id=external_state.id, values=(schedule,))\n",
     "                    await schedule_inputs\n",
     "\n",
-    "asyncio.run(cosimulate())"
+    "try:\n",
+    "    asyncio.run(cosimulate())\n",
+    "except RuntimeError:\n",
+    "    await cosimulate()"
    ]
   },
   {

--- a/examples/ground_segment_scheduling/optimization_cosimulation.ipynb
+++ b/examples/ground_segment_scheduling/optimization_cosimulation.ipynb
@@ -388,10 +388,7 @@
     "                    await channel.produce(agent_id=gs_agent.id, external_state_id=external_state.id, values=(schedule,))\n",
     "                    await schedule_inputs\n",
     "\n",
-    "try:\n",
-    "    asyncio.run(cosimulate())\n",
-    "except RuntimeError:\n",
-    "    await cosimulate()"
+    "await cosimulate()"
    ]
   },
   {


### PR DESCRIPTION
- In a script, `ayncio.run` must be used to call an async function (or to use any async capability really)
- In a jupyter notebook cell, `async.run` must not be used because running the cell creates a running event loop

An annoying problem, which I have solved by asking for forgiveness